### PR TITLE
PublicKey serialization and stringification

### DIFF
--- a/src/datatypes_interface.nim
+++ b/src/datatypes_interface.nim
@@ -23,6 +23,8 @@ when defined(backend_native):
 else:
   import ./backend_libsecp256k1/libsecp256k1
   export libsecp256k1.serialize
+  export libsecp256k1.`$`
+  export libsecp256k1.parsePublicKey
 
 # ################################
 # Initialization
@@ -63,3 +65,6 @@ proc sign_msg*(key: PrivateKey, message: string): Signature {.inline.} =
 
 proc sign_msg*(key: PrivateKey, message_hash: Hash[256]): Signature {.inline.} =
   ecdsa_sign(key, message_hash)
+
+proc `$`*(key: PrivateKey): string {.inline.} =
+  key.raw_key.toHex()

--- a/tests/test_private_public_key_consistency.nim
+++ b/tests/test_private_public_key_consistency.nim
@@ -17,6 +17,6 @@ suite "Testing private -> public key conversion":
     for person in [alice, bob, eve]:
       let privkey = initPrivateKey(person.privkey)
 
-      let computed_pubkey = privkey.public_key.serialize
+      let computed_pubkey = $privkey.public_key
 
-      check: computed_pubkey == "04" & person.pubkey # Serialization prefixes uncompressed public keys with 04
+      check: computed_pubkey == person.pubkey


### PR DESCRIPTION
* Added `proc serialize*(key: PublicKey, output: var openarray[byte], addPrefix = false)`
* Added `toString(PublicKey)` and `toStringWithPrefix(PublicKey)`.
* Added `$(PublicKey)`
* `parsePublicKey` now accepts both prefixed and unprefixed data.
*  Previous `serialize` is deprecated now