### PR TITLE
Use finalizers to avoid manual cleaning

### DIFF
--- a/eth_keys.nim
+++ b/eth_keys.nim
@@ -25,10 +25,6 @@ when not defined(native):
     ## Return current error message.
     result = libsecp256k1ErrorMsg()
 
-  proc shutdown*() {.inline.} =
-    ## Clean all backend resources
-    shutdownLibsecp256k1()
-
 proc signMessage*(seckey: PrivateKey,
                   data: openarray[byte]): Signature {.inline.} =
   ## Sign message of arbitrary length `data` using private key `seckey`.

--- a/eth_keys/libsecp256k1.nim
+++ b/eth_keys/libsecp256k1.nim
@@ -63,6 +63,7 @@ proc errorCallback(message: cstring, data: pointer) {.cdecl.} =
   ctx.error = $message
 
 proc shutdownLibsecp256k1(ekContext: EthKeysContext) =
+  # TODO: use destructor when finalizer are deprecated for destructors
   if not isNil(ekContext.context):
     secp256k1_context_destroy(ekContext.context)
 

--- a/eth_keys/libsecp256k1.nim
+++ b/eth_keys/libsecp256k1.nim
@@ -62,9 +62,13 @@ proc errorCallback(message: cstring, data: pointer) {.cdecl.} =
   let ctx = cast[EthKeysContext](data)
   ctx.error = $message
 
+proc shutdownLibsecp256k1(ekContext: EthKeysContext) =
+  if not isNil(ekContext.context):
+    secp256k1_context_destroy(ekContext.context)
+
 proc newEthKeysContext(): EthKeysContext =
   ## Create new `EthKeysContext`.
-  result = new EthKeysContext
+  new(result, shutdownLibsecp256k1)
   let flags = cuint(SECP256K1_CONTEXT_VERIFY or SECP256K1_CONTEXT_SIGN)
   result.context = secp256k1_context_create(flags)
   secp256k1_context_set_illegal_callback(result.context, illegalCallback,
@@ -313,8 +317,3 @@ proc signRawMessage*(data: openarray[byte], seckey: PrivateKey,
                                       nil, nil) != 1:
     return(EthKeysStatus.Error)
   return(EthKeysStatus.Success)
-
-proc shutdownLibsecp256k1() =
-  if not isNil(ekContext):
-    secp256k1_context_destroy(ekContext.context)
-    ekContext = nil


### PR DESCRIPTION
To avoid forgetting to call shutdown new contexts will automatically be paired with a finalizers.